### PR TITLE
修复获取外部存储目录时的NPE

### DIFF
--- a/wechat-qrcode/src/main/java/com/king/wechat/qrcode/WeChatQRCodeDetector.java
+++ b/wechat-qrcode/src/main/java/com/king/wechat/qrcode/WeChatQRCodeDetector.java
@@ -102,10 +102,6 @@ public final class WeChatQRCodeDetector {
      * @return
      */
     private static String getExternalFilesDir(Context context, String path) {
-        File[] files = context.getExternalFilesDirs(path);
-        if (files != null && files.length > 0) {
-            return files[0].getAbsolutePath();
-        }
         File file = context.getExternalFilesDir(path);
         if(file == null) {
             file = new File(context.getFilesDir(), path);


### PR DESCRIPTION
`Context.getExternalFilesDirs` 这个方法 returns the absolute paths to application-specific directories. Some individual paths may be null if that shared storage is not currently available. The first path returned is the same as getExternalFilesDir(String).
也就是说 `files[0].getAbsolutePath()` 可能会产生 NPE